### PR TITLE
-Add margin to signup form icons

### DIFF
--- a/ui/css/signup.css
+++ b/ui/css/signup.css
@@ -73,7 +73,7 @@ h2:after {
 }
 
 .input-row .fas {
-    margin-right: 5px;
+    margin-right: 20px;
     color: white;
     width: 10%;
 }


### PR DESCRIPTION
## What is the purpose of this PR
To add spacing to elements in the signup form
## Why is it Important
To enhance the look and feel of the app
## Relevant PT story
[#162178405](https://www.pivotaltracker.com/story/show/162178405)